### PR TITLE
gatherlogs hab package renamed to gatherlogs_reporter

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -5,7 +5,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/bash
   core/ruby
-  will/gatherlogs
+  will/gatherlogs_reporter
 )
 
 pkg_build_deps=(


### PR DESCRIPTION
Renamed the gatherlogs hab package to gatherlogs_reporter

Signed-off-by: Will Fisher <wfisher@chef.io>